### PR TITLE
Fix announcement URL

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -102,7 +102,7 @@ const config = {
         id: 'support_us',
         content:
           // 'We are revamping our docs, please <a href="mailto:developers@anthology.com?subject=New Developer Documentation Site: ">let us know what you think!</a> </br>Note:
-          'The Developer Portal will be updated June 6, 2023 at 1AM EDT. See <a href="http://localhost:3000/docs/Developer%20Portal/devportal-intro#release_notes" target="_top"> the Developer Portal release notes</a> for more detail.',
+          'The Developer Portal will be updated June 6, 2023 at 1AM EDT. See <a href="https://musical-adventure-wl1kq5k.pages.github.io/docs/Developer%20Portal/devportal-intro#release_notes" target="_top"> the Developer Portal release notes</a> for more detail.',
         backgroundColor: '#262626',
         textColor: '#d5d5d5',
         isCloseable: false,


### PR DESCRIPTION
Note going to have to change all localhost:3000 and github.io links to docs.anthology.com before going production.