### PR TITLE
Switch canonical docs domain back to docs.blackboard.com

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./build
-          cname: docs.anthology.com
+          cname: docs.blackboard.com
           # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,7 +14,8 @@ const config = {
   // Set the production url of your site here
   // url: 'https://blackboard.github.io',
   // url: 'https://anthologydevdocs.github.io',
-  url: 'https://docs.anthology.com',
+  // url: 'https://docs.anthology.com',
+  url: 'https://docs.blackboard.com',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   // baseUrl: '/',


### PR DESCRIPTION
## Summary
- `docs.blackboard.com`'s previous custom-domain binding (a stale Jekyll site in a personal fork owned by an ex-employee, `moneil/blackboard_docs`) has been decommissioned — its `CNAME` file was removed and GitHub Pages released the domain claim.
- This PR updates `docusaurus.config.js` and `.github/workflows/deploy.yml` so this repo's GitHub Pages site claims `docs.blackboard.com` as its canonical domain again (previously `docs.anthology.com`).
- `docs.anthology.com` will be freed by this change and picked up by a new, org-owned redirect repo (`blackboard/docs-anthology-redirect`) in a follow-up step, so it keeps working without depending on the old fork.

## Test plan
- [ ] Merge to `main`, confirm `deploy.yml` runs and publishes to `gh-pages` with the new `CNAME` file
- [ ] `gh api repos/blackboard/anthologydevdocs/pages` shows `cname: docs.blackboard.com` and an approved HTTPS cert
- [ ] `docs.blackboard.com` serves the live Docusaurus site directly with a valid cert
- [ ] Spot-check a few pages and the custom 404/redirect logic (`page-redirects.js`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)